### PR TITLE
military ambulance:limit to 3

### DIFF
--- a/factions/enemies_and_allies/units/military_ambulance/military_ambulance.xml
+++ b/factions/enemies_and_allies/units/military_ambulance/military_ambulance.xml
@@ -11,6 +11,7 @@
 		<sight value="11"/>
 		<time value="80"/>
 		<multi-selection value="true"/>
+		<max-unit-count value="3"/>
 		<cellmap value="false"/>
 		<levels>
 		</levels>


### PR DESCRIPTION
prevent the AI from building too many, and humans won't have much use for more than 3, as multiple boosts are not allowed